### PR TITLE
Improve service handling to help Packer builds. 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ consul_dns_port: 8600
 consul_configuration_template_path: consul.json.j2
 consul_logrotate_template_path: logrotate.j2
 consul_service_template_path: consul.service.j2
+consul_service_state: started
 
 # Consul nodes behaviour #
 consul_agent: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: restart consul
-  systemd:
-    name: consul
-    state: restarted
-  become: true

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,7 +5,6 @@
     dest: "{{ consul_configdir }}/consul.json"
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-  notify: restart consul
   become: true
 
 - name: Consul | Copy logrotate conf
@@ -23,5 +22,4 @@
     mode: 0644
     owner: root
     group: root
-  notify: restart consul
   become: true

--- a/tasks/consul_acl.yml
+++ b/tasks/consul_acl.yml
@@ -6,7 +6,6 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
     mode: 0640
-  notify: restart consul
   no_log: true
   when: consul_server
 
@@ -17,13 +16,8 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
     mode: 0640
-  notify: restart consul
   no_log: true
   when: consul_agent
-
-- name: Consul | ACLs system needs to be enabled prior to apply them
-  meta: flush_handlers
-  when: consul_acl  # This is to avoid triggering handlers unnecessarily
 
 - name: Consul | Install consul_acl prerequisites
   apt:
@@ -46,6 +40,5 @@
     rules: "{{ item.value.rules }}"
     mgmt_token: "{{ consul_acl_master_token }}"
     host: "{{ consul_server_nodes | first }}"
-  notify: restart consul
   with_dict: "{{ consul_acl_configuration_list }}"
   no_log: true

--- a/tasks/consul_services_registration.yml
+++ b/tasks/consul_services_registration.yml
@@ -9,7 +9,6 @@
     interval: "{{ item.interval | default (omit) }}"  # Interval between checks.
     tags: "{{ item.tags | default (omit) }}"
     token: "{{ consul_acl_agent_token }}"
-  notify: restart consul
   # We set this because of idempotency issues https://github.com/ansible/ansible-modules-extras/issues/1316
   changed_when: false
   no_log: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,7 +42,6 @@
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
     remote_src: yes
-  notify: restart consul
   become: true
 
 - name: Consul | Link binary

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -4,5 +4,5 @@
     name: consul
     enabled: true
     daemon_reload: true
-    state: started
+    state: "{{ consul_service_state }}"
   become: true


### PR DESCRIPTION
This PR fixes multiple issues around service restarts during the install process. In short this PR prevents the Consul service from being started during install inside Packer. This removes an issue of the Node ID clashing when the image is used more than once.